### PR TITLE
Demo instructions et al

### DIFF
--- a/FileUtils.java
+++ b/FileUtils.java
@@ -151,6 +151,25 @@ public class FileUtils
         return fileName.substring(0, len - 4);
     }
 
+    /**
+     * Check to see if folder is valid.
+     *
+     * @param dir directory file object
+     * @return true or false
+     */
+    public static Boolean readValidDirectory(File dir)
+    {
+        if (dir.exists() && dir.isDirectory())
+        {
+            String[] files = dir.list();
+            if (files.length > 0)
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+
     /** 
      * Read JSON file.
      *

--- a/README.md
+++ b/README.md
@@ -1,1 +1,11 @@
 # cs-5666-scatt-gp
+
+## Demo Instructions
+* Go to the [SCATT repo](https://github.com/JaysGitLab/cs-5666-scatt-gp).
+* Click the **Clone or download** button and choose **Download ZIP**.
+* Open/unzip the **cs-5666-scatt-gp.zip** file.
+* Open a terminal application (like PuTTY for Windows or Terminal for Mac).
+* Change to the **cs-5666-scatt-gp** directory.
+* Enter `make scatt` and hit return.
+* Enter the path to your SCATT submissions directory when prompted.
+* View the report output.

--- a/README.md
+++ b/README.md
@@ -1,9 +1,13 @@
 # cs-5666-scatt-gp
+The current deliverable for SCATT requires that you run the application on 
+Appalachian's student server, and that you have your Scratch .sb2 files in
+a folder within the application directory.
 
 ## Demo Instructions
 * Login to the Appalachian student server.
 * Clone the SCATT repo with the command `git clone https://github.com/JaysGitLab/cs-5666-scatt-gp.git`.
+* Copy the folder with your Scratch .sb2 files into the cd cs-5666-scatt-gp directory.
 * Go into the SCATT directory with the command `cd cs-5666-scatt-gp`.
 * Enter `make scatt` and hit return.
-* Enter the path to your SCATT submissions directory when prompted.
+* Enter the name of your SCATT submissions folder when prompted.
 * View the report output.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ## Demo Instructions
 * Go to the [SCATT repo](https://github.com/JaysGitLab/cs-5666-scatt-gp).
 * Click the **Clone or download** button and choose **Download ZIP**.
-* Open/unzip the **cs-5666-scatt-gp.zip** file.
+* Open/unzip the **cs-5666-scatt-gp-master.zip** file.
 * Open a terminal application (like PuTTY for Windows or Terminal for Mac).
 * Change to the **cs-5666-scatt-gp** directory.
 * Enter `make scatt` and hit return.

--- a/README.md
+++ b/README.md
@@ -1,11 +1,9 @@
 # cs-5666-scatt-gp
 
 ## Demo Instructions
-* Go to the [SCATT repo](https://github.com/JaysGitLab/cs-5666-scatt-gp).
-* Click the **Clone or download** button and choose **Download ZIP**.
-* Open/unzip the **cs-5666-scatt-gp-master.zip** file.
-* Open a terminal application (like PuTTY for Windows or Terminal for Mac).
-* Change to the **cs-5666-scatt-gp** directory.
+* Login to the Appalachian student server.
+* Clone the SCATT repo with the command `git clone https://github.com/JaysGitLab/cs-5666-scatt-gp.git`.
+* Go into the SCATT directory with the command `cd cs-5666-scatt-gp`.
 * Enter `make scatt` and hit return.
 * Enter the path to your SCATT submissions directory when prompted.
 * View the report output.

--- a/Scatt.java
+++ b/Scatt.java
@@ -56,5 +56,10 @@ public class Scatt
         
         Report report = new Report();
         report.makeReport();
+
+        for (int i = 0; i < submissions.length; i++)
+        {
+            submissions[i].deleteZips();
+        }
     }
 }

--- a/Scatt.java
+++ b/Scatt.java
@@ -27,7 +27,7 @@ public class Scatt
      */
     public static void main(String[] args)
     {
-        System.out.println("Please enter the folder path: ");
+        System.out.print("Please enter the folder path: ");
         String dirName = System.console().readLine();
         File directory = new File(dirName);
         Boolean isValid = FileUtils.readValidDirectory(directory);

--- a/Scatt.java
+++ b/Scatt.java
@@ -27,7 +27,7 @@ public class Scatt
      */
     public static void main(String[] args)
     {
-        System.out.print("Please enter the folder path: ");
+        System.out.print("Please enter the folder name: ");
         String dirName = System.console().readLine();
         File directory = new File(dirName);
         Boolean isValid = FileUtils.readValidDirectory(directory);

--- a/Scatt.java
+++ b/Scatt.java
@@ -27,13 +27,13 @@ public class Scatt
      */
     public static void main(String[] args)
     {
-        System.out.println("Please enter the folder name: ");
+        System.out.println("Please enter the folder path: ");
         String dirName = System.console().readLine();
         File directory = new File(dirName);
-        Boolean isValid = readValidDirectory(directory);
+        Boolean isValid = FileUtils.readValidDirectory(directory);
         if (!isValid)
         {
-            System.out.println("Invalid folder.");
+            System.out.println("Invalid folder path.");
             return;
         }
         
@@ -56,24 +56,5 @@ public class Scatt
         
         Report report = new Report();
         report.makeReport();
-    }
-
-    /**
-     * Check to see if folder is valid.
-     *
-     * @param dir directory file object
-     * @return true or false
-     */
-    public static Boolean readValidDirectory(File dir)
-    {
-        if (dir.exists() && dir.isDirectory())
-        {
-            String[] files = dir.list();
-            if (files.length > 0)
-            {
-                return true;
-            }
-        }
-        return false;
     }
 }

--- a/ScattTest.java
+++ b/ScattTest.java
@@ -42,7 +42,7 @@ public class ScattTest
     public void testValidFolder()
     {
         testDir = new File("submissions");
-        assertTrue(testScatt.readValidDirectory(testDir));
+        assertTrue(FileUtils.readValidDirectory(testDir));
     }
 
     /**
@@ -52,7 +52,7 @@ public class ScattTest
     public void testInvalidFolderNotDirectory()
     {
         testDir = new File("test.txt");
-        assertFalse(testScatt.readValidDirectory(testDir));
+        assertFalse(FileUtils.readValidDirectory(testDir));
     }
 
     /**
@@ -62,7 +62,7 @@ public class ScattTest
     public void testInvalidFolderEmpty()
     {
         testDir = new File("empty");
-        assertFalse(testScatt.readValidDirectory(testDir));
+        assertFalse(FileUtils.readValidDirectory(testDir));
     }
 
     /**

--- a/Submission.java
+++ b/Submission.java
@@ -139,4 +139,35 @@ public class Submission
     {
         return FileUtils.getJSONArrayAttribute(jsonObj, name);
     }
+
+    /**
+     * Delete zip files.
+     */
+    public void deleteZips()
+    {
+        if (zipsDir.exists())
+        {
+            File[] zipsDirFiles = zipsDir.listFiles();
+            for (int i = 0; i < zipsDirFiles.length; i++)
+            {
+                zipsDirFiles[i].delete();
+            }
+            zipsDir.delete();
+        }
+        
+        if (unzipsDir.exists())
+        {
+            File[] unzipsDirs = unzipsDir.listFiles();
+            for (int i = 0; i < unzipsDirs.length; i++)
+            {
+                File[] unzipFiles = unzipsDirs[i].listFiles();
+                for (int j = 0; j < unzipFiles.length; j++)
+                {
+                    unzipFiles[j].delete();
+                }
+                unzipsDirs[i].delete();
+            }
+            unzipsDir.delete();
+        }
+    }
 }

--- a/Submission.java
+++ b/Submission.java
@@ -117,11 +117,6 @@ public class Submission
                 e.printStackTrace();
             }
         }
-        else 
-        {
-            System.out.println("Invalid JSON file.");
-            return;
-        }
     }
 
     /**

--- a/SubmissionTest.java
+++ b/SubmissionTest.java
@@ -1,10 +1,11 @@
 import org.junit.Test;
-import org.junit.Before;
-import org.junit.After;
+import org.junit.BeforeClass;
+import org.junit.AfterClass;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertEquals;
 import java.io.File;
 import java.io.FileNotFoundException;
@@ -32,15 +33,16 @@ import org.json.simple.JSONArray;
  */
 public class SubmissionTest
 {
-    private File directory;
-    private File[] sb2s;
-    private Submission[] submissions;
+    private static File directory;
+    private static File expectedDir;
+    private static File[] sb2s;
+    private static Submission[] submissions;
     
     /**
      * Set up for tests.
      */
-    @Before
-    public void setUp()
+    @BeforeClass
+    public static void setUp()
     {
         // Set up expected files.
         directory = new File("submissions");
@@ -121,7 +123,7 @@ public class SubmissionTest
     public void testZip() throws IOException
     {
         // Copy and convert expected files to .zip.
-        File expectedDir = new File("expected");
+        expectedDir = new File("expected");
         if (!expectedDir.exists())
         {
             expectedDir.mkdir();
@@ -176,7 +178,7 @@ public class SubmissionTest
     public void testUnzip() throws IOException
     {
         // Get list of expected dir names.
-        File expectedDir = new File("expected");
+        expectedDir = new File("expected");
         File[] expectedZips = expectedDir.listFiles(); 
         String[] expected = new String[expectedZips.length]; 
         for (int i = 0; i < expected.length; i++)
@@ -290,15 +292,38 @@ public class SubmissionTest
             submissions[2].getJSONArrayAttribute("sounds").toString());
     }
 
+    /**
+     * Test deleteZips method.
+     */
+    @Test
+    public void testDeleteZips()
+    {
+        File zipsDir = new File("zips");
+        File unzipsDir = new File("unzips");
+        for (int i = 0; i < submissions.length; i++)
+        {
+            submissions[i].deleteZips();
+        }
+        assertFalse("should be false", zipsDir.exists() && unzipsDir.exists());
+    }
 
     /**
      * Tear down after tests.
      */
-    @After
-    public void tearDown()
+    @AfterClass
+    public static void tearDown()
     {
         // Set arrays to null.
         sb2s = null;
         submissions = null;
+        if (expectedDir.exists())
+        {
+            File[] expectedFiles = expectedDir.listFiles();
+            for (int i = 0; i < expectedFiles.length; i++)
+            {
+                expectedFiles[i].delete();
+            }
+            expectedDir.delete();
+        }
     }
 }

--- a/makefile
+++ b/makefile
@@ -10,20 +10,29 @@
 
 JUNIT_JAR = /usr/share/java/junit-4.10.jar
 HAMCREST_JAR = /usr/share/java/hamcrest/core-1.1.jar
+JSON_SIMPLE_JAR = json_simple.jar
 CKSTYLE_COMMAND =  -jar /usr/local/checkstyle-5.5/checkstyle-5.5-all.jar
+APP_FILES = Scatt.java Submission.java Report.java FileUtils.java
+TEST_FILES = ScattTest.java SubmissionTest.java ReportTest.java
+CLASS_FILES = Scatt.class Submission.class Report.class FileUtils.class
 
 default: 
 	@echo "usage: make target"
-	@echo "available targets: compile, test, clean, check, customcheck"
+	@echo "available targets: compile, jar, run, scatt, clean, test, check"
 
-compile: Scatt.java ScattTest.java Submission.java SubmissionTest.java FileUtils.java
-	javac -cp .:$(JUNIT_JAR):json_simple.jar ScattTest.java SubmissionTest.java
-	javac -cp .:json_simple.jar Scatt.java Submission.java FileUtils.java
+compile: $(APP_FILES) $(TEST_FILES)
+	javac -cp .:$(JUNIT_JAR):$(JSON_SIMPLE_JAR) $(TEST_FILES)
+	javac -cp .:$(JSON_SIMPLE_JAR) $(APP_FILES)
 
-jar: Scatt.class Submission.class FileUtils.class Report.class
-	jar -cvmf MANIFEST.MF Scatt.jar Scatt.class Submission.class FileUtils.class Report.class
+jar: $(CLASS_FILES)
+	jar -cvmf MANIFEST.MF Scatt.jar $(CLASS_FILES)
 
 run: Scatt.jar
+	java -jar Scatt.jar
+
+scatt: $(APP_FILES)
+	javac -cp .:$(JSON_SIMPLE_JAR) $(APP_FILES)
+	jar -cvmf MANIFEST.MF Scatt.jar $(CLASS_FILES)
 	java -jar Scatt.jar
 
 clean:
@@ -34,8 +43,9 @@ clean:
 	rm -rf unzips
 
 test: Submission.class SubmissionTest.class Scatt.class ScattTest.class FileUtils.class
-	java -cp .:$(JUNIT_JAR):$(HAMCREST_JAR):json_simple.jar org.junit.runner.JUnitCore SubmissionTest
+	java -cp .:$(JUNIT_JAR):$(HAMCREST_JAR):$(JSON_SIMPLE_JAR) org.junit.runner.JUnitCore SubmissionTest
+	java -cp .:$(JUNIT_JAR):$(HAMCREST_JAR) org.junit.runner.JUnitCore ReportTest
 	java -cp .:$(JUNIT_JAR):$(HAMCREST_JAR) org.junit.runner.JUnitCore ScattTest	
 
-check: Scatt.java ScattTest.java Submission.java SubmissionTest.java FileUtils.java Report.java ReportTest.java
-	checkstyle Scatt.java ScattTest.java Submission.java SubmissionTest.java FileUtils.java Report.java ReportTest.java
+check: $(APP_FILES) $(TEST_FILES)
+	checkstyle $(APP_FILES) $(TEST_FILES)


### PR DESCRIPTION
This pull request includes:
* Updating the makefile with macros (to make adding files to it simpler)
* Updating the makefile with a command for the client to use to demo the application
* Updating the README with demo instructions for the client (currently, we'll need the client to demo the application on the student server for simplicity - luckily we know he is familiar with it :); in one of our future iterations, we can add a story to make the executable jar OS independent)
* Moving the readValidDirectory method to the FileUtils class
* Removing the invalid json print statement (since we test for the json file != null before we perform any parsing, we don't need to output when there are invalid json files)
* Updating Submission and SubmissionTest to include a method to delete the zip files after the Report has been output

The demo instructions say to use the master branch ZIP since that's what this code will be - however to run the test on using the instructions, you'll need to clone this demo branch.