### PR TITLE
Add check for zips and unzips directories to test

### DIFF
--- a/SubmissionTest.java
+++ b/SubmissionTest.java
@@ -148,15 +148,21 @@ public class SubmissionTest
         
         // Get actual Submission filenames.
         File actualDir = new File("zips");
-        File[] actualZips = actualDir.listFiles();
-        Arrays.sort(actualZips);
-        String[] actual = new String[actualZips.length];
-        for (int i = 0; i < actual.length; i++)
+        
+        // Make sure directory has not been deleted 
+        // by deleteZips test or application. 
+        if (actualDir.exists())
         {
-            actual[i] = actualZips[i].getName();
-        }
+            File[] actualZips = actualDir.listFiles();
+            Arrays.sort(actualZips);
+            String[] actual = new String[actualZips.length];
+            for (int i = 0; i < actual.length; i++)
+            {
+                actual[i] = actualZips[i].getName();
+            }
 
-        assertArrayEquals("should be same", expected, actual);
+            assertArrayEquals("should be same", expected, actual);
+        }
     }
 
     /**
@@ -181,20 +187,27 @@ public class SubmissionTest
 
         // Get list of new zip dirs.
         File zipsDir = new File("unzips");
-        File[] zipDirs = zipsDir.listFiles();
-        Arrays.sort(zipDirs);
-        String[] actual = new String[zipDirs.length];
-        for (int i = 0; i < actual.length; i++)
-        {
-            // Only track directories with more than one file.
-            // Tests more than original zip file exists (unzip success).
-            if (zipDirs[i].isDirectory() && zipDirs[i].listFiles().length > 1)
-            {
-                actual[i] = zipDirs[i].getName();
-            }
-        }
 
-        assertArrayEquals("should be same", expected, actual);
+        // Make sure directory has not been deleted 
+        // by deleteZips test or application. 
+        if (zipsDir.exists())
+        {
+            File[] zipDirs = zipsDir.listFiles();
+            Arrays.sort(zipDirs);
+            String[] actual = new String[zipDirs.length];
+            for (int i = 0; i < actual.length; i++)
+            {
+                // Only track directories with more than one file.
+                // Tests more than original zip file exists (unzip success).
+                if (zipDirs[i].isDirectory() 
+                    && zipDirs[i].listFiles().length > 1)
+                {
+                    actual[i] = zipDirs[i].getName();
+                }
+            }
+
+            assertArrayEquals("should be same", expected, actual);
+        }
     }
 
     /**


### PR DESCRIPTION
Closes #49. 

The test error was actually coming from the testZip and testUnzip methods - the "zips" and "unzips" directories were being deleted by either the call to deleteZips in the main Scatt application, or in the testDeleteZips to test that method. Since the tests are not run in any specific order, this was causing the overlapping problem with the testZip and testUnzip methods. So I added an exists() test to those directories before running the testZip and testUnzip tests. This should resolve the sporadic error we were seeing. Thanks!